### PR TITLE
Allow individual digit settings for each table cell (similar to "xtable")

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ ztable 0.1.6
 
 * "ztable" is compatible with magrittr
 
+* Allow setting of individual digits for each table cell (similar to "xtable")
+
 
 ztable 0.1.5
 ============

--- a/R/ztable.R
+++ b/R/ztable.R
@@ -63,8 +63,9 @@ ztable.data.frame=function(x,digits=NULL,...){
 #'@param caption.bold whether or not use bold font for caption
 #'@param align Character vector : nchar equal to the number of columns of the
 #'       resulting table indicating the alignment of the corresponding columns.
-#'@param digits Numeric vector of length equal to one (in which case it will be
-#'       replicated as necessary) or to the number of columns of the resulting table
+#'@param digits A single value (in which case it will be replicated as necessary),
+#'       a numeric vector of length equal to the number of columns of the resulting
+#'       table or a matrix of the same size as the resulting table.
 #'@param display Character vector of length equal to the number of columns of the
 #'       resulting table indicating the format for the corresponding columns.
 #'       Since the row names are printed in the first column, the length of display
@@ -246,8 +247,11 @@ ztable_sub=function(x,
         if(include.rownames) for(i in 1:length(y)) align=paste(align,y[i],sep="")
         else for(i in 2:length(y)) align=paste(align,y[i],sep="")
     }
-    if(is.null(digits)) digits=c(0,rep(2,ncol(x)))
-    if(length(digits)==1) digits=rep(digits,ncount+1)
+    
+    if(is.null(digits)) digits=cbind(0, matrix(2, ncol=ncol(x), nrow=nrow(x)))
+    if(length(digits)==1) digits=cbind(0, matrix(digits, ncol=ncol(x), nrow=nrow(x)))
+    if(is.vector(digits) & length(digits)>1) digits=cbind(0, matrix(digits, ncol=length(digits), nrow=nrow(x), byrow=T))
+
     if (is.null(display)) {
         display <- rep("f", ncol(x))
         display[ints] <- "d"
@@ -510,8 +514,9 @@ repColor=function(x,color){
 #'@param caption.bold whether or not use bold font for caption
 #'@param align Character vector : nchar equal to the number of columns of the
 #'       resulting table indicating the alignment of the corresponding columns.
-#'@param digits Numeric vector of length equal to one (in which case it will be
-#'       replicated as necessary) or to the number of columns of the resulting table
+#'@param digits A single value (in which case it will be replicated as necessary),
+#'       a numeric vector of length equal to the number of columns of the resulting
+#'       table or a matrix of the same size as the resulting table.
 #'@param display Character vector of length equal to the number of columns of the
 #'       resulting table indicating the format for the corresponding columns.
 #'       Since the row names are printed in the first column, the length of display
@@ -642,8 +647,9 @@ update_ztable=function(z,
      if(!is.null(caption.bold)) z$caption.bold=caption.bold
      if(!is.null(align)) z$align=align
      if(!is.null(digits)) {
-         if(is.null(digits)) digits=c(0,rep(2,ncol(z$x)))
-         if(length(digits)==1) digits=rep(digits,ncol(z$x)+1)
+         if(is.null(digits)) digits=cbind(0, matrix(2, ncol=ncol(x), nrow=nrow(x)))
+         if(length(digits)==1) digits=cbind(0, matrix(digits, ncol=ncol(x), nrow=nrow(x)))
+         if(is.vector(digits) & length(digits)>1) digits=cbind(0, matrix(digits, ncol=length(digits), nrow=nrow(x), byrow=T))
          z$digits=digits
      }
      if(!is.null(display)) z$display=display
@@ -766,7 +772,7 @@ data2table=function(z){
                 if(is.na(z$x[i,j])) {
                     temp<-""
                 } else{
-                    temp<-formatC(z$x[i,j],digits=z$digits[j+1],
+                    temp<-formatC(z$x[i,j],digits=z$digits[i, j+1],
                                  format=z$display[j+1])
                 }
 


### PR DESCRIPTION
I patched `ztable_sub` to allow  individual digit settings for each table cell - maybe you'd like to include this function.